### PR TITLE
Apply \vee and | to TypeVar as well, fix #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,36 @@ julia> methods(@orunion (x::Int8 | UInt8)->5)
  [1] (::var"#35#36")(x::Union{Int8, UInt8})
 ```
 
+### `@∨` and `OrUnion.@|` are aliases for `@orunion`
+
+`@∨`, `@\vee[TAB]` and `OrUnion.@|` are provided as aliases for `@orunion`. `@∨` is exported. `OrUnion.@|` is not exported.
+
+To create your own alias, do `const var"@myalias" = var"@orunion"`.
+
+Here is some example usage of the macro aliases.
+
+```julia
+julia> using OrUnions
+
+julia> @∨ function foo(x::Int ∨ UInt, y::Float64 ∨ Nothing) end
+foo (generic function with 1 method)
+
+julia> methods(foo)
+# 1 method for generic function "foo" from Main:
+ [1] foo(x::Union{Int64, UInt64}, y::Union{Nothing, Float64})
+     @ REPL[2]:1
+
+julia> using OrUnions: @|
+
+julia> @| function bar(x::Int | UInt, y::Float64 | Nothing) end
+bar (generic function with 1 method)
+
+julia> methods(bar)
+# 1 method for generic function "bar" from Main:
+ [1] bar(x::Union{Int64, UInt64}, y::Union{Nothing, Float64})
+     @ REPL[5]:1
+```
+
 ## Using `OrUnion.:|`
 
 While `OrUnion.:|` is not exported, the definition can be used in your current module's namespace before `|` is used by explicitly by `using` the symbol as follows.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ julia> methods(g)
 
 Because of the parentheses, the resulting syntax differs from that of other languages.
 
+## `∨` operator in struct definitions
+
+`\vee` can also be used with `TypeVar`.
+
+```julia
+struct MyType{T <: Number}
+   x::(T ∨ Nothing)
+end
+```
+
 ## The macro `@orunion`
 
 The macro `@orunion` allows for the use of either `|` or `∨` without parentheses.
@@ -140,6 +150,21 @@ julia> methods(bar)
 # 1 method for generic function "bar" from Main:
  [1] bar(x::Union{Int64, UInt64}, y::Union{Nothing, Float64})
      @ REPL[5]:1
+
+julia> @| struct Foo{T <: Number | Signed}
+           x::T | Nothing
+       end
+
+julia> fieldtype(Foo{Int}, 1)
+Union{Nothing, Int64}
+
+julia> @macroexpand @| struct Foo{T <: Number | Signed}
+           x::T | Nothing
+       end
+:(struct Foo{T <: Union{Signed, Number}}
+      #= REPL[6]:2 =#
+      x::Union{Nothing, T}
+  end)
 ```
 
 ## Using `OrUnion.:|`

--- a/src/OrUnions.jl
+++ b/src/OrUnions.jl
@@ -38,8 +38,32 @@ const var"@∨" = var"@orunion"
 const var"@|" = var"@orunion"
 
 ## Dispatch on ex.head
-function macro_orunion!(ex)
+function macro_orunion!(arg)
+    return arg
+end
+
+function macro_orunion!(ex::Expr)
     macro_orunion!(Val(ex.head), ex)
+end
+
+function macro_orunion!(::Val, ex)
+    return ex
+end
+
+function macro_orunion!(::Val{:struct}, ex)
+    # Map type parameter declarations
+    if ex isa Expr && ex.args[2].head == :curly
+        for i in eachindex(ex.args[2].args)[2:end]
+            if ex.args[2].args[i] isa Expr
+                _, ex.args[2].args[i].args[2] = unionize_or!(ex.args[2].args[i].args[2])
+            end
+        end
+    end
+    # Map fields and constructors
+    for i in eachindex(ex.args[3].args)
+        ex.args[3].args[i] = macro_orunion!(ex.args[3].args[i])
+    end
+    return ex
 end
 
 function macro_orunion!(::Val{:function}, ex)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,6 +35,15 @@ using Test
     @test methods(@orunion((x::Int8 | Int16, y::Int32 | Int64)->x)).ms[1].sig.parameters[2] == Int8 ∨ Int16
     @test methods(@orunion((x::Int8 | Int16, y::Int32 | Int64)->x)).ms[1].sig.parameters[3] == Int32 ∨ Int64
 
+    struct MyType{T <: AbstractVector}
+        x::(T | Nothing)
+    end
+    @test fieldtype(MyType{Vector{Int}},1) == Union{Vector{Int}, Nothing}
+    struct MyType2{T <: AbstractVector}
+        x::(Nothing ∨ T)
+    end
+    @test fieldtype(MyType2{Vector{Int}},1) == Union{Vector{Int}, Nothing}
+
     # TODO:
     # @test methods(@orunion((x::Int8 | Int16)::(Int8 ∨ Int16) -> x))[1].sig.parameters[2] == Int8 ∨ Int16
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,6 +43,16 @@ using Test
         x::(Nothing ∨ T)
     end
     @test fieldtype(MyType2{Vector{Int}},1) == Union{Vector{Int}, Nothing}
+    struct MyType3{T <: AbstractVector, N <: Number}
+        x::(Nothing | T | N)
+        y::(Nothing ∨ T ∨ N)
+        z::(T | Nothing ∨ N)
+    end
+    @test fieldtype(MyType3{Vector{Int}, Float64},1) == Union{Vector{Int}, Nothing, Float64}
+    @test fieldtype(MyType3{Vector{Int}, Float64},2) == Union{Vector{Int}, Nothing, Float64}
+    @test fieldtype(MyType3{Vector{Int}, Float64},3) == Union{Vector{Int}, Nothing, Float64}
+    @test |(Int) == Int
+    @test ∨(Float64) == Float64
 
     # TODO:
     # @test methods(@orunion((x::Int8 | Int16)::(Int8 ∨ Int16) -> x))[1].sig.parameters[2] == Int8 ∨ Int16

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using OrUnions
-using OrUnions: |
+using OrUnions: |, @|
 using Test
 
 @testset "OrUnions.jl" begin
@@ -51,6 +51,15 @@ using Test
     @test fieldtype(MyType3{Vector{Int}, Float64},1) == Union{Vector{Int}, Nothing, Float64}
     @test fieldtype(MyType3{Vector{Int}, Float64},2) == Union{Vector{Int}, Nothing, Float64}
     @test fieldtype(MyType3{Vector{Int}, Float64},3) == Union{Vector{Int}, Nothing, Float64}
+    @| struct MyType4{T <: Number | Integer}
+        x::T | UInt
+        y::T | Float64
+        z::T | Nothing
+        MyType4() = new{Int}(1,1,1)
+    end
+    @test fieldtype(MyType4{Int}, 1) == Union{Int, UInt}
+    @test fieldtype(MyType4{Int}, 2) == Union{Int, Float64}
+    @test fieldtype(MyType4{Int}, 3) == Union{Int, Nothing}
     @test |(Int) == Int
     @test ∨(Float64) == Float64
 


### PR DESCRIPTION
Fix #1, for `TypeVar`

Also add documentation

Add `@\vee` and `@|` as aliases for `@orunion`